### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ StreamNative MCP Server provides a standard interface for LLMs (Large Language M
   - Connect directly to external Apache Kafka clusters
   - Connect directly to external Apache Pulsar clusters
 
-> *: The Kafka Connect operations are only tested and verfied on StreamNative Cloud. 
+> *: The Kafka Connect operations are only tested and verified on StreamNative Cloud. 
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- correct a spelling mistake in README

## Testing
- `grep -n verified -n README.md`