### PR TITLE
Fix nil checks in GetMcpContext

### DIFF
--- a/pkg/mcp/context.go
+++ b/pkg/mcp/context.go
@@ -27,7 +27,13 @@ func SetMcpContext(instance, cluster, organization string) {
 	McpContextOrganization = &organization
 }
 
+// GetMcpContext returns the currently configured StreamNative Cloud context.
+// If the context has not been fully configured, it returns empty strings.
 func GetMcpContext() (string, string, string) {
+	if McpContextPulsarInstance == nil || McpContextPulsarCluster == nil || McpContextOrganization == nil {
+		return "", "", ""
+	}
+
 	return *McpContextPulsarInstance, *McpContextPulsarCluster, *McpContextOrganization
 }
 

--- a/pkg/mcp/context_test.go
+++ b/pkg/mcp/context_test.go
@@ -1,0 +1,20 @@
+package mcp
+
+import "testing"
+
+func TestGetMcpContextUnset(t *testing.T) {
+	ResetMcpContext()
+	instance, cluster, org := GetMcpContext()
+	if instance != "" || cluster != "" || org != "" {
+		t.Fatalf("expected empty context when unset, got %q %q %q", instance, cluster, org)
+	}
+}
+
+func TestGetMcpContextSet(t *testing.T) {
+	ResetMcpContext()
+	SetMcpContext("inst", "cluster", "org")
+	instance, cluster, org := GetMcpContext()
+	if instance != "inst" || cluster != "cluster" || org != "org" {
+		t.Fatalf("expected context to be returned, got %q %q %q", instance, cluster, org)
+	}
+}


### PR DESCRIPTION
## Summary
- guard against nil values when reading context variables
- add tests for SetMcpContext and ResetMcpContext

## Testing
- `go test ./...` *(fails: go.work requires go >= 1.24.3)*